### PR TITLE
Add trace-driven to tl-test

### DIFF
--- a/Emu/Emu.cpp
+++ b/Emu/Emu.cpp
@@ -171,7 +171,8 @@ void Emu::execute(uint64_t nr_cycle) {
         }
 
         for (int i = 0; i < NR_AGENTS; i++) {
-            fuzzers[i]->tick();
+            if (enable_trace) fuzzers[i]->traceTest();
+            else fuzzers[i]->tick(); // random-test
         }
 
         for (int i = 0; i < NR_AGENTS; i++) {

--- a/Emu/Emu.cpp
+++ b/Emu/Emu.cpp
@@ -43,7 +43,9 @@ void Emu::parse_args(int argc, char **argv) {
 #endif
             case 't':
                 this->enable_trace = true;
-                this->trace_file = std::ifstream(optarg); break;
+                this->trace_file = std::ifstream(optarg);
+                printf("Trace format: 'timestamp, which L1, channel, opcode, address, param'\n");
+                break;
             default:
                 tlc_assert(false, "Unknown args!");
         }

--- a/Emu/Emu.cpp
+++ b/Emu/Emu.cpp
@@ -10,6 +10,7 @@ uint64_t Cycles;
 bool Verbose = false;
 bool dump_db = false;
 
+int trans_count = 0;
 double sc_time_stamp() { return 0; }
 
 void Emu::parse_args(int argc, char **argv) {

--- a/Emu/Emu.h
+++ b/Emu/Emu.h
@@ -13,6 +13,7 @@
 #endif
 #include "../Utils/ScoreBoard.h"
 #include "../Utils/Common.h"
+#include "../Utils/Trace.h"
 #include "../TLAgent/ULAgent.h"
 #include "../TLAgent/CAgent.h"
 #include "../Fuzzer/Fuzzer.h"
@@ -31,6 +32,9 @@ private:
     Fuzzer ** const fuzzers = new Fuzzer*[NR_AGENTS];
     uint64_t seed = 0, wave_begin = 0, wave_end = 0;
     bool enable_wave = true;
+    bool enable_trace = false;
+    std::ifstream trace_file;
+    std::queue<Transaction> transactions;
     bool wave_full = false;
     inline char* cycle_wavefile(uint64_t cycles, time_t t);
     void parse_args(int argc, char **argv);

--- a/Fuzzer/CFuzzer.cpp
+++ b/Fuzzer/CFuzzer.cpp
@@ -57,11 +57,11 @@ void CFuzzer::traceTest() {
     if (this->transactions.empty()) {
         return;
     }
-    Transaction transaction = this->transactions.front();
-    paddr_t addr = transaction.addr;
-    uint8_t channel = transaction.channel;
-    uint8_t opcode = transaction.opcode;
-    uint8_t param = transaction.param;
+    Transaction t = this->transactions.front();
+    paddr_t addr = t.addr;
+    uint8_t channel = t.channel;
+    uint8_t opcode = t.opcode;
+    uint8_t param = t.param;
     int send_status;
 
     switch (connect(channel, opcode))
@@ -74,15 +74,15 @@ void CFuzzer::traceTest() {
     // in fear of releaseData may have unknown bugs untested
     case (4 << 8) | tl_agent::ReleaseData:
     case (4 << 8) | tl_agent::Release:
-        send_status = this->cAgent->do_releaseDataAuto(addr, param);    break;
+        send_status = this->cAgent->do_releaseDataAuto(addr, 0);    break;
     default:
         std::cerr << "Error: Invalid Transaction " << channel << " Opcode " << opcode << std::endl;
         break;
     }
-
-    // if succeeded in sending it, remove it from queue
+    // printf("[DEBUG] tring to send %s\n", t.to_string().c_str());
+    // if succeeded/fail/pass to send, remove it from queue
     // TODO: whether still to send for PASS transations (whose permission is already satisfied)
-    if (send_status == tl_agent::SUCCESS || send_status == tl_agent::PASS) {
+    if (send_status != tl_agent::PENDING) {
         this->transactions.pop();
     }
     // otherwise try it next cycle

--- a/Fuzzer/CFuzzer.cpp
+++ b/Fuzzer/CFuzzer.cpp
@@ -80,8 +80,9 @@ void CFuzzer::traceTest() {
         break;
     }
 
-    // if succeeded in sending t, remove it from queue
-    if (send_status == 0) {
+    // if succeeded in sending it, remove it from queue
+    // TODO: whether still to send for PASS transations (whose permission is already satisfied)
+    if (send_status == tl_agent::SUCCESS || send_status == tl_agent::PASS) {
         this->transactions.pop();
     }
     // otherwise try it next cycle

--- a/Fuzzer/CFuzzer.cpp
+++ b/Fuzzer/CFuzzer.cpp
@@ -3,7 +3,7 @@
 //
 
 #include "Fuzzer.h"
-
+extern int trans_count;
 CFuzzer::CFuzzer(tl_agent::CAgent *cAgent) {
     this->cAgent = cAgent;
 }
@@ -85,6 +85,7 @@ void CFuzzer::traceTest() {
     if (send_status != tl_agent::PENDING) {
         this->transactions.pop();
     }
+    if (send_status == tl_agent::SUCCESS) trans_count++;
     // otherwise try it next cycle
 }
 

--- a/Fuzzer/Fuzzer.h
+++ b/Fuzzer/Fuzzer.h
@@ -20,6 +20,9 @@ public:
     void set_cycles(uint64_t *cycles) {
         this->cycles = cycles;
     }
+    void enqueue_transaction(Transaction &transaction) {
+        this->transactions.push(transaction);
+    }
 };
 
 class ULFuzzer: public Fuzzer {

--- a/Fuzzer/Fuzzer.h
+++ b/Fuzzer/Fuzzer.h
@@ -11,10 +11,12 @@
 class Fuzzer {
 protected:
     uint64_t *cycles;
+    std::queue<Transaction> transactions;
 public:
     Fuzzer() = default;
     ~Fuzzer() = default;
     virtual void tick() = 0;
+    virtual void traceTest() = 0;
     void set_cycles(uint64_t *cycles) {
         this->cycles = cycles;
     }
@@ -28,6 +30,7 @@ public:
     void randomTest(bool put);
     void caseTest();
     void caseTest2();
+    void traceTest();
     void tick();
 };
 
@@ -38,6 +41,7 @@ public:
     CFuzzer(tl_agent::CAgent *cAgent);
     void randomTest(bool do_alias);
     void caseTest();
+    void traceTest();
     void tick();
 };
 

--- a/Fuzzer/Fuzzer.h
+++ b/Fuzzer/Fuzzer.h
@@ -23,6 +23,9 @@ public:
     void enqueue_transaction(Transaction &transaction) {
         this->transactions.push(transaction);
     }
+    int get_queue_size() {
+        return this->transactions.size();
+    }
 };
 
 class ULFuzzer: public Fuzzer {

--- a/Fuzzer/ULFuzzer.cpp
+++ b/Fuzzer/ULFuzzer.cpp
@@ -57,3 +57,8 @@ void ULFuzzer::tick() {
     this->randomTest(false);
 //    this->caseTest();
 }
+
+void ULFuzzer::traceTest() {
+  printf("[ERROR] TraceTest for ULFuzzer Not Implemented!\n");
+  exit(1);
+}

--- a/TLAgent/BaseAgent.h
+++ b/TLAgent/BaseAgent.h
@@ -14,6 +14,13 @@ namespace tl_agent {
 
     enum Resp {OK, FAIL};
 
+    // return value for `do_acquireBlock`
+    // 0 for successful sending
+    // 1 for unable to send now (congestion)
+    // 2 for failure due to action not allowed
+    // 3 for permission already satisfied (no need to send Acquire)
+    enum TransResp {SUCCESS, PENDING, FAILURE, PASS};
+
     enum {
         S_INVALID = 0,
         S_VALID,

--- a/TLAgent/CAgent.cpp
+++ b/TLAgent/CAgent.cpp
@@ -596,8 +596,10 @@ namespace tl_agent {
     }
 
     TransResp CAgent::do_releaseData(paddr_t address, int param, uint8_t data[], int alias) {
-        if (pendingC.is_pending() || pendingB.is_pending() || idpool.full() || !localBoard->haskey(address))
+        if (pendingC.is_pending() || pendingB.is_pending() || idpool.full())
             return PENDING;
+        if (!localBoard->haskey(address))
+            return PASS;
         // TODO: checkout pendingA
         // TODO: checkout pendingB - give way?
         auto entry = localBoard->query(address);
@@ -630,8 +632,10 @@ namespace tl_agent {
     }
 
     TransResp CAgent::do_releaseDataAuto(paddr_t address, int alias) {
-        if (pendingC.is_pending() || pendingB.is_pending() || idpool.full() || !localBoard->haskey(address))
+        if (pendingC.is_pending() || pendingB.is_pending() || idpool.full())
             return PENDING;
+        if (!localBoard->haskey(address))
+            return PASS;
         // TODO: checkout pendingA
         // TODO: checkout pendingB - give way?
         auto entry = localBoard->query(address);

--- a/TLAgent/CAgent.cpp
+++ b/TLAgent/CAgent.cpp
@@ -506,9 +506,9 @@ namespace tl_agent {
         probeIDpool.update();
     }
 
-    bool CAgent::do_acquireBlock(paddr_t address, int param, int alias) {
+    TransResp CAgent::do_acquireBlock(paddr_t address, int param, int alias) {
         if (pendingA.is_pending() || pendingB.is_pending() || idpool.full())
-            return false;
+            return PENDING;
         if (localBoard->haskey(address)) { // check whether this transaction is legal
             auto entry = localBoard->query(address);
             auto privilege = entry->privilege[alias];
@@ -518,18 +518,18 @@ namespace tl_agent {
                 status[i] = entry->status[i];
             }
             if (status[alias] != S_VALID && status[alias] != S_INVALID) {
-                return false;
+                return PENDING; // in the process of other transaction
             }
             if (status[alias] == S_VALID) {
-                if (privilege == TIP) return false;
+                if (privilege == TIP) return PASS;
                 // if (privilege == BRANCH && param != BtoT) { param = BtoT; }
-                if (privilege == BRANCH && param != BtoT) return false;
-                if (privilege == INVALID && param == BtoT) return false;
+                if (privilege == BRANCH && param != BtoT) return PASS;
+                if (privilege == INVALID && param == BtoT) return FAILURE;
             }
             for(int i = 0; i < 4; i++) {
-                // do not send Release when there is an Acquire with the same address waiting for Grant
+                // do not send Release when there is an Acquire with the same physical address waiting for Grant
                 if(status[i] == S_A_WAITING_D || status[i] == S_A_WAITING_D_INTR) {
-                    return false;   
+                    return PENDING;
                 }
             }
         }
@@ -552,12 +552,12 @@ namespace tl_agent {
             break;
         }
 
-        return true;
+        return SUCCESS;
     }
 
-    bool CAgent::do_acquirePerm(paddr_t address, int param, int alias) {
+    TransResp CAgent::do_acquirePerm(paddr_t address, int param, int alias) {
         if (pendingA.is_pending() || pendingB.is_pending() || idpool.full())
-            return false;
+            return PENDING;
         if (localBoard->haskey(address)) {
             auto entry = localBoard->query(address);
             auto privilege = entry->privilege[alias];
@@ -567,17 +567,17 @@ namespace tl_agent {
                 status[i] = entry->status[i];
             }
             if (status[alias] != S_VALID && status[alias] != S_INVALID) {
-                return false;
+                return PENDING;
             }
             if (status[alias] == S_VALID) {
-                if (privilege == TIP) return false;
+                if (privilege == TIP) return PASS;
                 if (privilege == BRANCH && param != BtoT) { param = BtoT; }
-                if (privilege == INVALID && param == BtoT) return false;
+                if (privilege == INVALID && param == BtoT) return FAILURE;
             }
             for(int i = 0; i < 4; i++) {
-                // do not send AcquirePerm when there is an Acquire with the same address waiting for Grant
+                // do not send AcquirePerm when there is an Acquire with the same physical address waiting for Grant
                 if(status[i] == S_A_WAITING_D || status[i] == S_A_WAITING_D_INTR) {
-                    return false;   
+                    return PENDING;
                 }
             }
         }
@@ -592,23 +592,23 @@ namespace tl_agent {
         // Log("== id == acquire %d\n", *req_a->source);
         pendingA.init(req_a, 1);
         Log("[%ld] [AcquirePerm] addr: %x alias: %d\n", *cycles, address, alias);
-        return true;
+        return SUCCESS;
     }
 
-    bool CAgent::do_releaseData(paddr_t address, int param, uint8_t data[], int alias) {
+    TransResp CAgent::do_releaseData(paddr_t address, int param, uint8_t data[], int alias) {
         if (pendingC.is_pending() || pendingB.is_pending() || idpool.full() || !localBoard->haskey(address))
-            return false;
+            return PENDING;
         // TODO: checkout pendingA
         // TODO: checkout pendingB - give way?
         auto entry = localBoard->query(address);
         auto privilege = entry->privilege[alias];
         auto status = entry->status[alias];
         if (status != S_VALID) {
-            return false;
+            return FAILURE;
         }
-        if (privilege == INVALID) return false;
-        if (privilege == BRANCH && param != BtoN) return false;
-        if (privilege == TIP && param == BtoN) return false;
+        if (privilege == INVALID) return FAILURE;
+        if (privilege == BRANCH && param != BtoN) return FAILURE;
+        if (privilege == TIP && param == BtoN) return FAILURE;
 
         std::shared_ptr<ChnC<ReqField, EchoField, DATASIZE>> req_c(new ChnC<ReqField, EchoField, DATASIZE>());
         req_c->opcode = new uint8_t(ReleaseData);
@@ -626,12 +626,12 @@ namespace tl_agent {
             Dump("%02hhx", data[i]);
         }
         Dump("\n");
-        return true;
+        return SUCCESS;
     }
 
-    bool CAgent::do_releaseDataAuto(paddr_t address, int alias) {
+    TransResp CAgent::do_releaseDataAuto(paddr_t address, int alias) {
         if (pendingC.is_pending() || pendingB.is_pending() || idpool.full() || !localBoard->haskey(address))
-            return false;
+            return PENDING;
         // TODO: checkout pendingA
         // TODO: checkout pendingB - give way?
         auto entry = localBoard->query(address);
@@ -639,7 +639,7 @@ namespace tl_agent {
         int param;
         switch (privilege) {
         case INVALID:
-            return false;
+            return FAILURE;
         case BRANCH:
             param = BtoN;
             break;
@@ -655,12 +655,12 @@ namespace tl_agent {
             status[i] = entry->status[i];
         }
         if (status[alias] != S_VALID) {
-            return false;
+            return FAILURE;
         }
         for(int i = 0; i < 4; i++) {
-         // do not send Release when there is an Acquire with the same address waiting for Grant
+         // do not send Release when there is an Acquire with the same physical address waiting for Grant
             if(status[i] == S_A_WAITING_D || status[i] == S_A_WAITING_D_INTR) {
-                return false;   
+                return PENDING;
             }
         }
 
@@ -725,7 +725,7 @@ namespace tl_agent {
             Dump("\n");
         }
 
-        return true;
+        return SUCCESS;
     }
 
     void CAgent::timeout_check() {

--- a/TLAgent/CAgent.h
+++ b/TLAgent/CAgent.h
@@ -8,6 +8,7 @@
 #include "BaseAgent.h"
 #include "../Utils/Common.h"
 #include "../Utils/ScoreBoard.h"
+#include "../Utils/Trace.h"
 
 namespace tl_agent {
 

--- a/TLAgent/CAgent.h
+++ b/TLAgent/CAgent.h
@@ -90,10 +90,10 @@ namespace tl_agent {
         void handle_channel();
         void update_signal();
 
-        bool do_acquireBlock(paddr_t address, int param, int alias);
-        bool do_acquirePerm(paddr_t address, int param, int alias);
-        bool do_releaseData(paddr_t address, int param, uint8_t data[], int alias);
-        bool do_releaseDataAuto(paddr_t address, int alias);
+        TransResp do_acquireBlock(paddr_t address, int param, int alias);
+        TransResp do_acquirePerm(paddr_t address, int param, int alias);
+        TransResp do_releaseData(paddr_t address, int param, uint8_t data[], int alias);
+        TransResp do_releaseDataAuto(paddr_t address, int alias);
     };
 
 }

--- a/TLAgent/ULAgent.cpp
+++ b/TLAgent/ULAgent.cpp
@@ -161,9 +161,9 @@ namespace tl_agent {
         idpool.update();
     }
     
-    bool ULAgent::do_getAuto(paddr_t address) {
+    TransResp ULAgent::do_getAuto(paddr_t address) {
         if (pendingA.is_pending() || idpool.full())
-            return false;
+            return PENDING;
         std::shared_ptr<ChnA<ReqField, EchoField, DATASIZE>> req_a(new ChnA<ReqField, EchoField, DATASIZE>());
         req_a->opcode = new uint8_t(Get);
         req_a->address = new paddr_t(address);
@@ -172,12 +172,12 @@ namespace tl_agent {
         req_a->source = new uint8_t(this->idpool.getid());
         pendingA.init(req_a, 1);
         Log("[%ld] [Get] addr: %x\n", *cycles, address);
-        return true;
+        return SUCCESS;
     }
 
-    bool ULAgent::do_get(paddr_t address, uint8_t size, uint32_t mask) {
+    TransResp ULAgent::do_get(paddr_t address, uint8_t size, uint32_t mask) {
         if (pendingA.is_pending() || idpool.full())
-            return false;
+            return PENDING;
         std::shared_ptr<ChnA<ReqField, EchoField, DATASIZE>> req_a(new ChnA<ReqField, EchoField, DATASIZE>());
         req_a->opcode = new uint8_t(Get);
         req_a->address = new paddr_t(address);
@@ -186,14 +186,14 @@ namespace tl_agent {
         req_a->source = new uint8_t(this->idpool.getid());
         pendingA.init(req_a, 1);
         Log("[%ld] [Get] addr: %x size: %x\n", *cycles, address, size);
-        return true;
+        return SUCCESS;
     }
     
-    bool ULAgent::do_putfulldata(uint16_t address, uint8_t data[]) {
+    TransResp ULAgent::do_putfulldata(uint16_t address, uint8_t data[]) {
         if (pendingA.is_pending() || idpool.full())
-            return false;
+            return PENDING;
         if (this->globalBoard->haskey(address) && this->globalBoard->query(address)->status == Global_SBEntry::SB_PENDING) {
-            return false;
+            return PENDING;
         }
         std::shared_ptr<ChnA<ReqField, EchoField, DATASIZE>> req_a(new ChnA<ReqField, EchoField, DATASIZE>());
         req_a->opcode = new uint8_t(PutFullData);
@@ -208,14 +208,14 @@ namespace tl_agent {
             Dump("%02hhx", data[i]);
         }
         Dump("\n");
-        return true;
+        return SUCCESS;
     }
 
-    bool ULAgent::do_putpartialdata(uint16_t address, uint8_t size, uint32_t mask, uint8_t data[]) {
+    TransResp ULAgent::do_putpartialdata(uint16_t address, uint8_t size, uint32_t mask, uint8_t data[]) {
         if (pendingA.is_pending() || idpool.full())
-            return false;
+            return PENDING;
         if (this->globalBoard->haskey(address) && this->globalBoard->query(address)->status == Global_SBEntry::SB_PENDING)
-            return false;
+            return PENDING;
         std::shared_ptr<ChnA<ReqField, EchoField, DATASIZE>> req_a(new ChnA<ReqField, EchoField, DATASIZE>());
         req_a->opcode = new uint8_t(PutPartialData);
         req_a->address = new paddr_t(address);
@@ -230,7 +230,7 @@ namespace tl_agent {
             Dump("%02hhx", data[i]);
         }
         Dump("\n");
-        return true;
+        return SUCCESS;
     }
     
     void ULAgent::timeout_check() {

--- a/TLAgent/ULAgent.cpp
+++ b/TLAgent/ULAgent.cpp
@@ -189,7 +189,7 @@ namespace tl_agent {
         return SUCCESS;
     }
     
-    TransResp ULAgent::do_putfulldata(uint16_t address, uint8_t data[]) {
+    TransResp ULAgent::do_putfulldata(paddr_t address, uint8_t data[]) {
         if (pendingA.is_pending() || idpool.full())
             return PENDING;
         if (this->globalBoard->haskey(address) && this->globalBoard->query(address)->status == Global_SBEntry::SB_PENDING) {
@@ -211,7 +211,7 @@ namespace tl_agent {
         return SUCCESS;
     }
 
-    TransResp ULAgent::do_putpartialdata(uint16_t address, uint8_t size, uint32_t mask, uint8_t data[]) {
+    TransResp ULAgent::do_putpartialdata(paddr_t address, uint8_t size, uint32_t mask, uint8_t data[]) {
         if (pendingA.is_pending() || idpool.full())
             return PENDING;
         if (this->globalBoard->haskey(address) && this->globalBoard->query(address)->status == Global_SBEntry::SB_PENDING)

--- a/TLAgent/ULAgent.h
+++ b/TLAgent/ULAgent.h
@@ -65,7 +65,7 @@ namespace tl_agent {
         TransResp do_getAuto(paddr_t address);
         TransResp do_get(paddr_t address, uint8_t size, uint32_t mask);
         TransResp do_putfulldata(paddr_t address, uint8_t data[]);
-        TransResp do_putpartialdata(uint16_t address, uint8_t size, uint32_t mask, uint8_t data[]);
+        TransResp do_putpartialdata(paddr_t address, uint8_t size, uint32_t mask, uint8_t data[]);
     };
 
 }

--- a/TLAgent/ULAgent.h
+++ b/TLAgent/ULAgent.h
@@ -8,6 +8,7 @@
 #include "BaseAgent.h"
 #include "../Utils/Common.h"
 #include "../Utils/ScoreBoard.h"
+#include "../Utils/Trace.h"
 
 namespace tl_agent {
 

--- a/TLAgent/ULAgent.h
+++ b/TLAgent/ULAgent.h
@@ -62,10 +62,10 @@ namespace tl_agent {
         void fire_e();
         void handle_channel();
         void update_signal();
-        bool do_getAuto(paddr_t address);
-        bool do_get(paddr_t address, uint8_t size, uint32_t mask);
-        bool do_putfulldata(paddr_t address, uint8_t data[]);
-        bool do_putpartialdata(uint16_t address, uint8_t size, uint32_t mask, uint8_t data[]);
+        TransResp do_getAuto(paddr_t address);
+        TransResp do_get(paddr_t address, uint8_t size, uint32_t mask);
+        TransResp do_putfulldata(paddr_t address, uint8_t data[]);
+        TransResp do_putpartialdata(uint16_t address, uint8_t size, uint32_t mask, uint8_t data[]);
     };
 
 }

--- a/Utils/Trace.h
+++ b/Utils/Trace.h
@@ -44,7 +44,7 @@ public:
         this->agentId = std::stoi(tokens[1]);
         this->channel = std::stoi(tokens[2]);
         this->opcode = std::stoi(tokens[3]);
-        this->addr = std::stoul(tokens[4], nullptr, 16); // assume addr in hex base
+        this->addr = std::stoul(tokens[4]);
     }
 
     std::string to_string() {

--- a/Utils/Trace.h
+++ b/Utils/Trace.h
@@ -8,6 +8,7 @@
 #include <queue>
 
 #define READ_ONCE 5000
+#define END_TIMER 20000 // cycles to run after trace all sent
 
 // TODO: consider alias and other user fields
 class Transaction {

--- a/Utils/Trace.h
+++ b/Utils/Trace.h
@@ -1,0 +1,56 @@
+#ifndef TRACE_H
+#define TRACE_H
+
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <sstream>
+#include <queue>
+
+#define READ_ONCE 5000
+
+class Transaction {
+public:
+    uint32_t timestamp;
+    uint8_t agentId;
+    uint8_t channel;
+    uint8_t opcode;
+    paddr_t addr;
+    uint8_t param;
+
+    Transaction(uint32_t timestamp, uint8_t agentId, uint8_t channel, uint8_t opcode, paddr_t addr, uint8_t param) {
+        this->timestamp = timestamp;
+        this->agentId = agentId;
+        this->channel = channel;
+        this->opcode = opcode;
+        this->addr = addr;
+        this->param = param;
+    }
+
+    Transaction(std::string line) {
+        std::istringstream iss(line);
+        std::string token;
+        std::vector<std::string> tokens;
+        while (std::getline(iss, token, ',')) {
+            tokens.push_back(token);
+        }
+        if (tokens.size() != 6) {
+            std::cerr << "Error: invalid trace line: " << line << std::endl;
+            exit(1);
+        }
+        this->timestamp = std::stoi(tokens[0]);
+        this->agentId = std::stoi(tokens[1]);
+        this->channel = std::stoi(tokens[2]);
+        this->opcode = std::stoi(tokens[3]);
+        this->addr = std::stoul(tokens[4], nullptr, 16); // assume addr in hex base
+    }
+
+    std::string to_string() {
+        std::ostringstream oss;
+        oss << timestamp << ":" << (int)agentId << ":" << (int)channel << "," << (int)opcode << "," << std::hex << addr << "," << (int)param;
+        return oss.str();
+    }
+};
+
+
+#endif //TRACE_H

--- a/Utils/Trace.h
+++ b/Utils/Trace.h
@@ -9,6 +9,7 @@
 
 #define READ_ONCE 5000
 
+// TODO: consider alias and other user fields
 class Transaction {
 public:
     uint32_t timestamp;

--- a/main.cpp
+++ b/main.cpp
@@ -2,6 +2,7 @@
 #include <csignal>
 #include "Emu/Emu.h"
 
+extern int trans_count;
 int main(int argc, char **argv) {
     std::signal(SIGABRT, abortHandler);
 
@@ -9,5 +10,6 @@ int main(int argc, char **argv) {
     emu.reset(10);
     emu.execute(emu.exe_cycles);
     std::cout << std::endl << "Finished" << std::endl;
+    std::cout << "Transcations: " << trans_count << std::endl;
     return 0;
 }


### PR DESCRIPTION
- Allow trace as input (format 'timestamp, which L1, channel, opcode, address, param') 
- Support read large tracefile block by block
- Send transaction until its timestamp (when Cycles >= t.timestamp)